### PR TITLE
Add build list capability to factory

### DIFF
--- a/spec/factory.spec.ts
+++ b/spec/factory.spec.ts
@@ -78,5 +78,13 @@ describe('factories build stuff', () => {
     const bond = personFactory.build({firstName: 'James'});
     expect(bond.fullName).to.eq('James Bond');
   });
+  it('can build a list of items', () => {
+    const children = childFactory.buildList(3, {name: "Bruce"});
+    expect(children.length).to.eq(3);
+    for(let child of children) {
+      expect(child.name).to.eq('Bruce');
+      expect(child.grade).to.eq(1);
+    }
+  });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,15 @@ export class Factory<T> {
 
   }
 
+  public buildList(count: number, item: Partial<T>) : T[]
+  {
+    const ts: T[] = [];
+    for(let i = 0; i < count; i++) {
+      ts[i] = this.build(item);
+    }
+    return ts;
+  }
+
   public extend(def: Partial<Builder<T>>) : Factory<T> {
     const builder = Object.assign({}, this.builder, def);
     return new Factory(builder);


### PR DESCRIPTION
### Goal

To allow a factory to build a number of type instances.

### Implementation

Introduce `#buildList` method on `Factory` which takes a `count` of items to build and the same `item` instance description that `#build` takes. It simply builds an array the same length as `count`, calling `#build` to generate each instance.