### PR TITLE
#11: move seqNum increment to after first loop iteration

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -23,7 +23,6 @@ export class Factory<T> {
   }
 
   public build(item?: RecPartial<T>): T {
-    this.seqNum++;
     const base = buildBase(this.seqNum, this.builder);
     let v = Object.assign({}, base.value); //, item);
     if (item) {
@@ -35,6 +34,7 @@ export class Factory<T> {
         }
       }
     }
+    this.seqNum++;
     return v;
   }
 


### PR DESCRIPTION
This PR addressed #11 and moved the sequence incrementation to after the first pass of the loop. Doing so allows the first index of the test data array to be hit.