### PR TITLE
Building an object uses lodash's cloneDeep

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "webpack-dev-server": "^1.16.2"
   },
   "dependencies": {
+    "lodash": "^4.17.11",
     "source-map-support": "^0.5.9",
     "tslint": "^5.11.0"
   }

--- a/spec/sync.spec.ts
+++ b/spec/sync.spec.ts
@@ -214,4 +214,20 @@ describe("factories build stuff", () => {
     const a = factoryA.build();
     expect(a.foo).toEqual(4);
   })
+  it("clones deeply nested values", () => {
+    interface TypeA {
+      bar: {
+        baz: string;
+      }
+    }
+    const factoryA = Factory.makeFactory<TypeA>({
+      bar: {
+        baz: "should-be-immutable"
+      }
+    });
+    const a = factoryA.build();
+    const b = factoryA.build();
+    a.bar.baz = "is-not-immutable";
+    expect(b.bar.baz).toEqual("should-be-immutable")
+  });
 });

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,4 +1,5 @@
 import { RecPartial } from "./shared";
+import * as cloneDeep from "lodash/cloneDeep";
 
 export interface SyncFactoryConfig {
   readonly startingSequenceNumber?: number
@@ -218,6 +219,8 @@ function buildBase<T>(seqNum: number, builder: Builder<T>): BaseBuild<T> {
         value = v.build(seqNum);
       } else if (v.constructor == Derived) {
         derived.push({ key, derived: v });
+      } else {
+        value = cloneDeep(v);
       }
     }
     t[key] = value;


### PR DESCRIPTION
This avoids the unexpected scenario of mutating a factory value and then unexpectedly seeing changes across all factory values.
