### PR TITLE
Building an object useing clone-deep

### DIFF
--- a/interfaces/clone-deep.d.ts
+++ b/interfaces/clone-deep.d.ts
@@ -1,0 +1,1 @@
+declare module "clone-deep";

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "webpack-dev-server": "^1.16.2"
   },
   "dependencies": {
+    "clone-deep": "^4.0.1",
     "source-map-support": "^0.5.9",
     "tslint": "^5.11.0"
   }

--- a/spec/async.spec.ts
+++ b/spec/async.spec.ts
@@ -264,5 +264,21 @@ describe("async factories build stuff", () => {
     }, { startingSequenceNumber: 3 });
     const a = await factoryA.build();
     expect(a.foo).toEqual(4);
-  })
+  });
+  it("clones deeply nested values", async () => {
+    interface TypeA {
+      bar: {
+        baz: string;
+      };
+    }
+    const factoryA = Async.makeFactory<TypeA>({
+      bar: {
+        baz: "should-be-immutable"
+      }
+    });
+    const a = await factoryA.build();
+    const b = await factoryA.build();
+    a.bar.baz = "is-not-immutable";
+    expect(b.bar.baz).toEqual("should-be-immutable");
+  });
 });

--- a/spec/sync.spec.ts
+++ b/spec/sync.spec.ts
@@ -214,4 +214,20 @@ describe("factories build stuff", () => {
     const a = factoryA.build();
     expect(a.foo).toEqual(4);
   })
+  it("clones deeply nested values", () => {
+    interface TypeA {
+      bar: {
+        baz: string;
+      }
+    }
+    const factoryA = Factory.makeFactory<TypeA>({
+      bar: {
+        baz: "should-be-immutable"
+      }
+    });
+    const a = factoryA.build();
+    const b = factoryA.build();
+    a.bar.baz = "is-not-immutable";
+    expect(b.bar.baz).toEqual("should-be-immutable")
+  });
 });

--- a/src/async.ts
+++ b/src/async.ts
@@ -1,6 +1,7 @@
 import { RecPartial } from "./shared";
 import * as Sync from "./sync";
 import { Async } from ".";
+import * as cloneDeep from "clone-deep";
 
 export interface AsyncFactoryConfig {
   readonly startingSequenceNumber?: number
@@ -284,6 +285,8 @@ async function buildBase<T>(
         value = (v as Sync.Generator<any>).build(seqNum);
       } else if (v.constructor == Sync.Derived) {
         derived.push({ key, derived: new Derived(v.func) });
+      } else {
+        value = cloneDeep(v);
       }
     }
     t[key] = value;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,4 +1,5 @@
 import { RecPartial } from "./shared";
+import * as cloneDeep from "clone-deep";
 
 export interface SyncFactoryConfig {
   readonly startingSequenceNumber?: number
@@ -218,6 +219,8 @@ function buildBase<T>(seqNum: number, builder: Builder<T>): BaseBuild<T> {
         value = v.build(seqNum);
       } else if (v.constructor == Derived) {
         derived.push({ key, derived: v });
+      } else {
+        value = cloneDeep(v);
       }
     }
     t[key] = value;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "include": ["src", "interfaces"],
   "compilerOptions": {
     "declaration": true,
     "outDir": "lib",


### PR DESCRIPTION
This avoids the unexpected scenario of mutating a factory object and then unexpectedly seeing changes across all factory objects.

See https://github.com/jonschlinkert/clone-deep/