### PR TITLE
README: Include installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ Version 0.3.2 introduces a new set of async factory methods for cases where asyn
 
 Version 0.3.3 introduces a pipeline mechanism for building up a key-value set of data. See pipeline.spec.ts for an example.
 
+## Installation
+
+Install using yarn:
+
+```
+yarn add -D factory.ts
+```
+
+Install using npm:
+
+```
+npm install --save-dev factory.ts
+```
+
 ## Example
 
 ### Interface


### PR DESCRIPTION
yarn or npm packages don't usually have a '.ts' at the end of the package,
so adding the installation command can be useful.

yarn add -D factory.ts
