### PR TITLE
Support multiple override items in build list

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -68,11 +68,12 @@ export class Factory<T, K extends keyof T = keyof T> {
 
   public buildList = ((
     count: number,
-    item?: RecPartial<T> & Omit<T, K>
+    item?: RecPartial<T> & Omit<T, K> | Array<RecPartial<T> & Omit<T, K>>
   ): T[] => {
+    const items = Array.isArray(item) ? item : [item];
     const ts: T[] = Array(count); // allocate to correct size
     for (let i = 0; i < count; i++) {
-      ts[i] = this.build(item as any);
+      ts[i] = this.build((items[i] || items[0]) as any);
     }
     return ts;
   }) as ListFactoryFunc<T, K>;


### PR DESCRIPTION
WDYT?

So instead of:
```
build({a: 1});
buildList(2, {a:2});
```

We can do:
```
buildList(3, [{a: 2}, {a: 1}]);
```