### PR TITLE
fixes for derivations

### DIFF
--- a/spec/async.spec.ts
+++ b/spec/async.spec.ts
@@ -323,6 +323,34 @@ describe("async factories build stuff", () => {
     const obj2 = await tenXFactory.build({ fooz: 25 });
     expect(obj2.fooz).toEqual(25);
   });
+  it("successfully overrides a derivation", async () => {
+    interface A {
+      prop1: string;
+      prop2: string;
+      prop3: string;
+    }
+
+    interface B {
+      a: A;
+      b: string;
+    }
+    const factory2 = Async.makeFactory<B>(
+      {
+        a: {} as A,
+        b: "value",
+      }).withDerivation("a", async (b) => ({
+        prop1: b.b,
+        prop2: b.b,
+        prop3: b.b,
+      }));
+    expect(await factory2.build({ b: "b" })).toEqual({
+      a: { prop1: "b", prop2: "b", prop3: "b" }, b: "b"
+    });
+    expect(await factory2.build({ b: "b", a: { prop1: "a" } })).toEqual({
+      a: { prop1: "a" }, b: "b"
+    });
+
+  });
   it.skip("supports tuples at root (TODO)", async () => {
     const generator: Async.Generator<[number, number]> = Async.each<
       [number, number]

--- a/spec/sync.spec.ts
+++ b/spec/sync.spec.ts
@@ -98,6 +98,36 @@ describe("factories build stuff", () => {
     const doubleO = personFactory.build();
     expect(doubleO.fullName).toEqual("Double-O Bond");
   });
+  it("successfully overrides a derivation", () => {
+    interface A {
+      prop1: string;
+      prop2: string;
+      prop3: string;
+    }
+
+    interface B {
+      a: A;
+      b: string;
+    }
+    const factory2 = Sync.makeFactory<B>(() => {
+      const value = "value";
+      return {
+        a: {} as A,
+        b: value,
+      };
+    }).withDerivation("a", (b) => ({
+      prop1: b.b,
+      prop2: b.b,
+      prop3: b.b,
+    }));
+    expect(factory2.build({ b: "b" })).toEqual({
+      a: { prop1: "b", prop2: "b", prop3: "b" }, b: "b"
+    });
+    expect(factory2.build({ b: "b", a: { prop1: "a" } })).toEqual({
+      a: { prop1: "a" }, b: "b"
+    });
+
+  });
   it("can build a list of items", () => {
     const children = childFactory.buildList(3, { name: "Bruce" });
     expect(children.length).toEqual(3);

--- a/src/async.ts
+++ b/src/async.ts
@@ -28,7 +28,7 @@ export function lift<T>(t: T | Promise<T>): Promise<T> {
 }
 
 export class Generator<T> {
-  constructor(readonly func: (seq: number) => T | Promise<T>) {}
+  constructor(readonly func: (seq: number) => T | Promise<T>) { }
   public build(seq: number): Promise<T> {
     return lift(this.func(seq));
   }
@@ -39,7 +39,7 @@ export class Derived<TOwner, TProperty> {
       owner: TOwner,
       seq: number
     ) => TProperty | Promise<TProperty>
-  ) {}
+  ) { }
   public build(owner: TOwner, seq: number): Promise<TProperty> {
     return lift(this.func(owner, seq));
   }
@@ -51,8 +51,7 @@ export interface IFactory<T, K extends keyof T, U> {
 }
 
 export class Factory<T, K extends keyof T = keyof T>
-  implements IFactory<T, K, T>
-{
+  implements IFactory<T, K, T> {
   private seqNum: number;
   private getStartingSequenceNumber = () =>
     (this.config && this.config.startingSequenceNumber) || 0;
@@ -258,12 +257,11 @@ export class Factory<T, K extends keyof T = keyof T>
 }
 
 export class TransformFactory<T, K extends keyof T, U>
-  implements IFactory<T, K, U>
-{
+  implements IFactory<T, K, U> {
   constructor(
     private readonly inner: Factory<T, K>,
     private readonly transform: (t: T) => U | Promise<U>
-  ) {}
+  ) { }
   public build = (async (item?: RecPartial<T> & Omit<T, K>): Promise<U> => {
     const v = await this.inner.build(item as any);
     const u = await lift(this.transform(v));
@@ -319,10 +317,12 @@ async function buildBase<T, K extends keyof T>(
         value = await (v as Generator<any>).build(seqNum);
       } else if (v.constructor == Derived) {
         derived.push({ key, derived: v });
+        value = {};
       } else if (v.constructor === Sync.Generator) {
         value = (v as Sync.Generator<any>).build(seqNum);
       } else if (v.constructor == Sync.Derived) {
         derived.push({ key, derived: new Derived(v.func) });
+        value = {};
       } else {
         value = cloneDeep(v);
       }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -14,13 +14,13 @@ export type ListFactoryFunc<T, K extends keyof T> = keyof T extends K
   : (count: number, item: RecPartial<T> & Omit<T, K>) => T[];
 
 export class Generator<T> {
-  constructor(readonly func: (seq: number) => T) {}
+  constructor(readonly func: (seq: number) => T) { }
   public build(seq: number): T {
     return this.func(seq);
   }
 }
 export class Derived<TOwner, TProperty> {
-  constructor(readonly func: (owner: TOwner, seq: number) => TProperty) {}
+  constructor(readonly func: (owner: TOwner, seq: number) => TProperty) { }
   public build(owner: TOwner, seq: number): TProperty {
     const ret = this.func(owner, seq);
     return ret;
@@ -268,6 +268,7 @@ function buildBase<T, K extends keyof T>(
         value = v.build(seqNum);
       } else if (v.constructor == Derived) {
         derived.push({ key, derived: v });
+        value = {};
       } else {
         value = cloneDeep(v);
       }


### PR DESCRIPTION
Derivation functions did not clear the base object when "registering" themselves, so there was still a key 'func' left over when a derivation was overridden by an actual Factory.build() call.

Fixes #41 